### PR TITLE
Fixed URL concatenation

### DIFF
--- a/src/main/kotlin/by/dev/madhead/doktor/confluence/addLabels.kt
+++ b/src/main/kotlin/by/dev/madhead/doktor/confluence/addLabels.kt
@@ -12,7 +12,7 @@ import io.reactivex.Single
 import java.net.URL
 
 fun addLabels(confluenceServer: ResolvedConfluenceServer, id: String, labels: Labels): Single<AddLabelsResponse> {
-	return URL(URL(confluenceServer.url), "/rest/api/content/${id}/label").toString()
+	return URL(URL(confluenceServer.url).toExternalForm() + "/rest/api/content/${id}/label").toString()
 		.httpPost()
 		.apply {
 			if (!confluenceServer.user.isNullOrBlank()) {

--- a/src/main/kotlin/by/dev/madhead/doktor/confluence/createAttachment.kt
+++ b/src/main/kotlin/by/dev/madhead/doktor/confluence/createAttachment.kt
@@ -12,7 +12,7 @@ import io.reactivex.Single
 import java.net.URL
 
 fun createAttachment(confluenceServer: ResolvedConfluenceServer, id: String, attachment: Attachment): Single<CreateAttachmentResponse> {
-	return URL(URL(confluenceServer.url), "/rest/api/content/${id}/child/attachment").toString()
+	return URL(URL(confluenceServer.url).toExternalForm() + "/rest/api/content/${id}/child/attachment").toString()
 		.httpUpload()
 		.apply {
 			if (!confluenceServer.user.isNullOrBlank()) {

--- a/src/main/kotlin/by/dev/madhead/doktor/confluence/createPage.kt
+++ b/src/main/kotlin/by/dev/madhead/doktor/confluence/createPage.kt
@@ -11,7 +11,7 @@ import io.reactivex.Single
 import java.net.URL
 
 fun createPage(confluenceServer: ResolvedConfluenceServer, createPageRequest: CreatePageRequest): Single<CreatePageResponse> {
-	return URL(URL(confluenceServer.url), "/rest/api/content").toString()
+	return URL(URL(confluenceServer.url).toExternalForm() + "/rest/api/content").toString()
 		.httpPost()
 		.apply {
 			if (!confluenceServer.user.isNullOrBlank()) {

--- a/src/main/kotlin/by/dev/madhead/doktor/confluence/deletePage.kt
+++ b/src/main/kotlin/by/dev/madhead/doktor/confluence/deletePage.kt
@@ -9,7 +9,7 @@ import io.reactivex.Completable
 import java.net.URL
 
 fun deletePage(confluenceServer: ResolvedConfluenceServer, id: String): Completable {
-	return URL(URL(confluenceServer.url), "/rest/api/content/${id}").toString()
+	return URL(URL(confluenceServer.url).toExternalForm() + "/rest/api/content/${id}").toString()
 		.httpDelete()
 		.apply {
 			if (!confluenceServer.user.isNullOrBlank()) {

--- a/src/main/kotlin/by/dev/madhead/doktor/confluence/findPage.kt
+++ b/src/main/kotlin/by/dev/madhead/doktor/confluence/findPage.kt
@@ -11,7 +11,7 @@ import io.reactivex.Maybe
 import java.net.URL
 
 fun findPage(confluenceServer: ResolvedConfluenceServer, title: String): Maybe<ContentReference> {
-	return URL(URL(confluenceServer.url), "/rest/api/content").toString()
+	return URL(URL(confluenceServer.url).toExternalForm() + "/rest/api/content").toString()
 		.httpGet(
 			listOf(
 				"spaceKey" to confluenceServer.space,


### PR DESCRIPTION
`java.net.URL` constructor does cut off the relative path of the URL when initializing with a new relative path. See: https://stackoverflow.com/q/7498030/1873085

This fixes #63 